### PR TITLE
Feature/44/correct-amount-of-active-properties-for-agent

### DIFF
--- a/Controllers/PropertyController.cs
+++ b/Controllers/PropertyController.cs
@@ -43,13 +43,13 @@ public class PropertyController : ControllerBase
             .Include(p => p.Agent) // will return "404 NOT FOUND" if newly created Property's AgentId is 0/ unassigned
                 .ThenInclude(a => a.UserProfile)
             .Include(p => p.Agent)
-                .ThenInclude(a => a.Properties)
+                .ThenInclude(a => a.Properties.Where(prop => prop.IsActive)) // Filter active properties
             .Include(p => p.PropertyInvestors) // will be ok and return empty array if newly created Property's Investors is unassigned
                 .ThenInclude(pi => pi.Investor)
                     .ThenInclude(a => a.UserProfile)
             .SingleOrDefault(p => p.Id == id);
 
-        if (property == null || property.IsActive == false) //filter out non-active property, too
+        if (property == null || property.IsActive == false) //filter out non-active property, too; or use !property.IsActive 
         {
             return NotFound();
         }


### PR DESCRIPTION
filter the properties from the related Agent entity to only include active properties with .Where()