### PR TITLE
Feature/84/admin only path protection

### DIFF
--- a/client/src/components/ApplicationViews.js
+++ b/client/src/components/ApplicationViews.js
@@ -27,10 +27,10 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser, search
           }
         />
         <Route
-          path="pathName1"
+          path="dashboard"
           element={
-            <AuthorizedRoute loggedInUser={loggedInUser}>
-              <p>PathName1</p>
+            <AuthorizedRoute roles={["Admin"]} loggedInUser={loggedInUser}>
+              <Dashboard />
             </AuthorizedRoute>
           }
         />
@@ -103,7 +103,7 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser, search
             </AuthorizedRoute>
           }
         />
-        
+
         <Route
           path="pie"
           element={

--- a/client/src/components/ApplicationViews.js
+++ b/client/src/components/ApplicationViews.js
@@ -12,6 +12,7 @@ import Dashboard from "../scenes/dashboard/index.js";
 import Bar from "../scenes/bar-chart/index.js";
 import Line from "../scenes/line-chart/index.js";
 import Pie from "../scenes/pie-chart/index.js";
+import { HomeRedirect } from "./HomeRedirect.js";
 
 
 export default function ApplicationViews({ loggedInUser, setLoggedInUser, searchTerm, setSearchTerm }) {
@@ -22,7 +23,7 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser, search
           index
           element={
             <AuthorizedRoute loggedInUser={loggedInUser}>
-              <Dashboard />
+              <HomeRedirect roles={["Admin"]} loggedInUser={loggedInUser} />{/* Redirect Based on User Roles */}
             </AuthorizedRoute>
           }
         />

--- a/client/src/components/HomeRedirect.js
+++ b/client/src/components/HomeRedirect.js
@@ -1,0 +1,19 @@
+import { Navigate } from "react-router-dom";
+
+// This component returns a Route that either display the prop element
+// or navigates to the login. If roles are provided, the route will require
+// all of the roles when all is true, or any of the roles when all is false
+export const HomeRedirect = ({  loggedInUser, roles, all }) => {
+    let admin = false;
+    if (loggedInUser) {
+        if (roles && roles.length) {
+            admin = all
+                ? roles.every((r) => loggedInUser.roles.includes(r))
+                : roles.some((r) => loggedInUser.roles.includes(r));
+        } else {
+            admin = true;
+        }
+    }
+
+    return admin ? <Navigate to="/dashboard" /> : <Navigate to="/properties" />;
+};

--- a/client/src/scenes/auth/Login.js
+++ b/client/src/scenes/auth/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { login } from "../../managers/authManager";
 import {
@@ -26,6 +26,9 @@ export default function Login({ setLoggedInUser }) {
       }
     });
   };
+
+  useEffect(() => { setLoggedInUser(null) }, []);
+  /* to prevent sidebar and topbar still rendered when loggedin non-admin user try to navigate to admin-only path using web browser's URL address bar  */
 
   return (
     <Container component="main" maxWidth="sm" >

--- a/client/src/scenes/dashboard/index.js
+++ b/client/src/scenes/dashboard/index.js
@@ -224,7 +224,9 @@ const Dashboard = () => {
                                 </Typography>
                             </Stack>
                             <Box color={colors.greenAccent[500]} flex={0.5}> {/* flex makes a flexbox inside, good for positioning */}
-                                {Array(5 - index).fill(<StarsOutlinedIcon key={index} />)}
+                                {Array(5 - index).fill(0).map((_, starIndex) => (
+                                    <StarsOutlinedIcon key={`${agent.id}-star-${starIndex}`} />
+                                ))}
                             </Box>
                             <Box
                                 backgroundColor={colors.greenAccent[500]}
@@ -296,7 +298,7 @@ const Dashboard = () => {
                     <Box display="flex" height="300px" m="-10px 0 0 0">
 
                         {isLargeScreen && (<PieChart data={mockPieData} isDashboard={true} isPrimary={false} />)}
-                        
+
                         <PieChart data={mockPieData2} isDashboard={true} isPrimary={false} />
                     </Box>
 


### PR DESCRIPTION
- [x]  HomeRedirect: non-admin user's will see /properties not /dashboard when first logged in
- [x]  AuthorizedRoute: when non-admin user type /dashboard or /bar /line /pie, it will require log in
- [x]  Login: prevent sidebar and topbar still rendered when loggedin non-admin user try to navigate to admin-only path using web browser's URL address bar

close #84 